### PR TITLE
Fix getForecastDataByStationId to make it return a forecast

### DIFF
--- a/bom.ts
+++ b/bom.ts
@@ -391,7 +391,7 @@ export class Bom {
 
   async getForecastDataByStationBomId(bomId: number | string, stateFilter?: string) {
     const station = await this.getStationByBomId(bomId, stateFilter)
-    return station
+    return this._getForecastDataByStation(station)
   }
 
   async getForecastData(latitude: number, longitude: number) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-bom",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Currently it returns a station like `getStationByBomId` does and not the forecast.